### PR TITLE
Please add monky-quit-window

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -1288,6 +1288,12 @@ With a prefix argument, visit in other window."
     ((missing file)
      (monky-revert-file info))))
 
+(defun monky-quit-window (&optional kill-buffer)
+  "Bury the buffer and delete its window.  With a prefix argument, kill the
+buffer instead."
+  (interactive "P")
+  (quit-window kill-buffer (selected-window)))
+
 ;;; Refresh
 
 (defun monky-revert-buffers (dir &optional ignore-modtime)


### PR DESCRIPTION
It's just a copy of `magit-quit-window`.

Furthermore, I think it's better to bind "q" for this function and re-bind `monky-queue` to "Q", like this tkf/monky@074f0b127852591e4e1c1a5dbc82fa79f56e1afe.
