### PR TITLE
add bookmark and phase labels in log buffer

### DIFF
--- a/style/log-graph
+++ b/style/log-graph
@@ -1,4 +1,5 @@
-changeset = "{node} <branches>{branches}</branches><tags>{tags}</tags>{desc|firstline}\n"
+changeset = "{node} <branches>{branches}</branches><tags>{tags}</tags><bookmarks>{bookmarks}</bookmarks><phase>{phase|escape}</phase>{desc|firstline}\n"
 
 branch = '<branch>{branch|escape}</branch>'
 tag = '<tag>{tag|escape}</tag>'
+bookmark = '<bookmark>{bookmark|escape}</bookmark>'


### PR DESCRIPTION
Although phase is supported from Mercurial 2.1, it works in the previous versions. I checked with 1.9.1.
