### PR TITLE
fix monky-log: set default-directory and monky-root-dir

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -2013,6 +2013,8 @@ before the last command."
   (monky-with-process
     (let ((topdir (monky-get-root-dir)))
       (pop-to-buffer monky-log-buffer-name)
+      (setq default-directory topdir
+            monky-root-dir topdir)
       (monky-mode-init topdir 'log #'monky-refresh-log-buffer)
       (monky-log-mode t))))
 


### PR DESCRIPTION
In the previous version, you had the bug when opening the log of different repositories using cmdserver.  When you open `*monky-log*` for the first time, that's fine. But when you open `*monky-log*` for another repository, you cannot see its commits (diffs and messages). This is because monky tried to read data from the first repository which is specified by the buffer local variable `monky-root-dir`.
