### PR TITLE
monky-get-root-dir doesn't work with remote repositories

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -1600,9 +1600,24 @@ before the last command."
 
 ;; TODO needs cleanup
 (defun monky-get-root-dir ()
+  (if (and (featurep 'tramp)
+	   (tramp-tramp-file-p default-directory))
+      (monky-get-tramp-root-dir)
+    (monky-get-local-root-dir)))
+
+(defun monky-get-local-root-dir ()
   (let ((root (monky-hg-string "root")))
     (if root
-        (concat root "/")
+	(concat root "/")
+      (error "Not inside a hg repo"))))
+
+(defun monky-get-tramp-root-dir ()
+  (let ((root (monky-hg-string "root"))
+	(tramp-path (tramp-dissect-file-name default-directory)))
+    (if root
+	(progn (aset tramp-path 3 root)
+	       (concat (apply 'tramp-make-tramp-file-name (append tramp-path ()))
+		       "/"))
       (error "Not inside a hg repo"))))
 
 (defun monky-find-buffer (submode &optional dir)


### PR DESCRIPTION
monky-get-root-dir uses "hg root" to get the root for the repository.
When we are working with remote repositories, we need to convert the output to a tramp path.
