### PR TITLE
Byte-compile fix.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,11 @@ VERSION=0.1
 ELS=monky.el
 DIST_FILES=$(ELS) Makefile monky.texi monky.info README.md monky-pkg.el.in monky-pkg.el
 
+all: monky.elc monky.info
+
+monky.elc: monky.el
+	emacs -Q --batch -f batch-byte-compile monky.el
+
 monky-pkg.el: monky-pkg.el.in
 	sed -e s/@VERSION@/$(VERSION)/ < $< > $@
 

--- a/monky.el
+++ b/monky.el
@@ -24,7 +24,7 @@
 
 ;;; Code:
 
-(require 'cl)
+(eval-when-compile (require 'cl))
 (require 'bindat)
 
 (defgroup monky nil


### PR DESCRIPTION
Changes in monky.el are needed to byte-compile the file.
