### PR TITLE
move log buffer after showing commit

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -887,9 +887,9 @@ CMD is an external command that will be run with ARGS as arguments"
         (monky-log-show-more-entries)
         (monky-goto-next-section)))
      (next
-      (goto-char (monky-section-beginning next))
       (if (memq monky-submode '(log blame))
           (monky-show-commit next))
+      (goto-char (monky-section-beginning next))
       (if (not (monky-section-hidden next))
           (let ((offset (- (line-number-at-pos
                             (monky-section-beginning next))


### PR DESCRIPTION
This change fixed a problem in monky-goto-next-section: As `(monky-show-commit next)` takes a little time, previous version "shakes" when go down to the commit which is in the next page.

By the way, why do you need recenter in monky-goto-next-section? You don't have it in monky-goto-previous-section, right?  I also think current behavior is a little bit strange because hitting `n` always moves the next section at the bottom if possible (i.e., there is a space to scroll down), even if the current section was not at the bottom.  You can check if the current section is at the bottom or not before moving the cursor, but I think it introduces unnecessary complexity.  I think removing `(recenter offset)` is better solution.  What do you think?
