### PR TITLE
Fix '/' and '\' compares in 'monky-find-buffer.

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -1628,7 +1628,7 @@ before the last command."
       (error "Not inside a hg repo"))))
 
 (defun monky-find-buffer (submode &optional dir)
-  (let ((rootdir (or dir (monky-get-root-dir))))
+  (let ((rootdir (expand-file-name (or dir (monky-get-root-dir)))))
     (find-if (lambda (buf)
                (with-current-buffer buf
                  (and default-directory


### PR DESCRIPTION
On windows if I don't expand the file name here then the 'equal later compares '/' and '\' path seps, failing.
