### PR TITLE
Fix cmdserver when mercurial is in ascii encoding

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -423,7 +423,11 @@ refreshes buffers."
   "Get encoding stored in `monky-cmd-hello-message'."
   (let ((e (assoc 'encoding monky-cmd-hello-message)))
     (if e
-        (intern (downcase (cdr e)))
+        (cond
+         ((string-equal (downcase (cdr e)) "ascii")
+          'us-ascii)
+         (t
+          (intern (downcase (cdr e)))))
       default)))
 
 (defun monky-cmdserver-runcommand (&rest cmd-and-args)


### PR DESCRIPTION
When hg hello message give ascii encoding, we switch to 'us-ascii emacs encoding instead on non-existing 'ascii.
