### PR TITLE
Fixing problem with spaces in file name.

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -1796,7 +1796,7 @@ before the last command."
   (cadr (monky-section-info diff)))
 
 (defun monky-diff-line-file ()
-  (cond ((looking-at "^diff -r \\(.*\\) \\(.*\\)$")
+  (cond ((looking-at "^diff -r \\([^ ]*\\) \\(.*\\)$")
          (match-string-no-properties 2))
         (t
          nil)))


### PR DESCRIPTION
When a file name contains spaces, monky-diff-line-file doesn't display the diff.