### PR TITLE
Update graph handling for modern hg.

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -2061,7 +2061,7 @@ PROPERTIES is the arguments for the function `propertize'."
 
 (defvar monky-log-graph-re
   (concat
-   "^\\([-\\/@o+|\s]+\s*\\) "           ; 1. graph
+   "^\\([-\\/@xo+|\s]+\s*\\) "          ; 1. graph
    "\\([a-z0-9]\\{40\\}\\) "            ; 2. id
    "<branches>\\(.?*\\)</branches>"     ; 3. branches
    "<tags>\\(.?*\\)</tags>"             ; 4. tags
@@ -2109,7 +2109,7 @@ Example:
           (monky-set-section-info id)
           (when monky-log-count (incf monky-log-count))
           (forward-line)
-          (when (looking-at "^\\([\\/@o+-|\s]+\s*\\)$")
+          (when (looking-at "^\\([\\/@xo+-|\s]+\s*\\)$")
             (let ((graph (match-string 1)))
               (insert "         ")
               (forward-line))))

--- a/monky.el
+++ b/monky.el
@@ -2059,9 +2059,11 @@ PROPERTIES is the arguments for the function `propertize'."
       (monky-mode-init topdir 'log #'monky-refresh-log-buffer)
       (monky-log-mode t))))
 
+(setq monky-graph-chars "\\([\\/\:\~@xo+-|\s]+\s*\\)")
+
 (defvar monky-log-graph-re
   (concat
-   "^\\([-\\/@xo+|\s]+\s*\\) "          ; 1. graph
+   "^" monky-graph-chars " "            ; 1. graph
    "\\([a-z0-9]\\{40\\}\\) "            ; 2. id
    "<branches>\\(.?*\\)</branches>"     ; 3. branches
    "<tags>\\(.?*\\)</tags>"             ; 4. tags
@@ -2109,7 +2111,13 @@ Example:
           (monky-set-section-info id)
           (when monky-log-count (incf monky-log-count))
           (forward-line)
-          (when (looking-at "^\\([\\/@xo+-|\s]+\s*\\)$")
+
+          ;; consume all intermediate graph lines
+          (while (and
+                  ;; The line does *not* look like a line with log XML
+                  (not (looking-at (concat "^" monky-graph-chars " <")))
+                  ;; but it *does* look like a graph line
+                  (looking-at (concat "^" monky-graph-chars "$")))
             (let ((graph (match-string 1)))
               (insert "         ")
               (forward-line))))


### PR DESCRIPTION
Some upcoming hg workflows support obsolete commits, which are shown with an 'x' in the ASCII graph. The first commit handles that.

The next major release of hg (3.8, due out in just a couple of weeks on May 1) adds some brevity to the graph output that currently confuses monky - that's the second commit.
