### PR TITLE
New features

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -2566,7 +2566,7 @@ With a non numeric prefix ARG, show all entries"
      (monky-checkout info))))
 
 (defun monky-merge-item ()
-  "Checkout the revision represented by current item."
+  "Merge the revision represented by current item."
   (interactive)
   (monky-section-action (item info "merge")
     ((branch)

--- a/monky.el
+++ b/monky.el
@@ -113,15 +113,10 @@ is usually faster if Monky runs several commands."
   :type '(choice (const :tag "Single processes" :value nil)
                  (const :tag "Use command server" :value cmdserver)))
 
-(defcustom monky-run-update-after-pull nil
-  "Run update after pulling."
+(defcustom monky-pull-args ""
+  "Extra args to pass to pull."
   :group 'monky
-  :type 'boolean)
-
-(defcustom monky-run-rebase-after-pull nil
-  "Run rebase after pulling."
-  :group 'monky
-  :type 'boolean)
+  :type 'string)
 
 (defcustom monky-repository-paths nil
   "*Paths where to find repositories.  For each repository an alias is defined, which can then be passed to `monky-open-repository` to open the repository.
@@ -1447,13 +1442,7 @@ With a prefix argument, visit in other window."
   (let ((remote (if current-prefix-arg
                     (monky-read-remote "Pull from : ")
                   monky-incoming-repository)))
-    (cond (monky-run-update-after-pull
-	   (monky-run-hg-sync "pull" remote)
-	   (monky-run-hg-async "update" "--tool" "internal:merge"))
-	  (monky-run-rebase-after-pull
-	   (monky-run-hg-sync "pull" remote)
-	   (monky-run-hg-async "rebase" "--tool" "internal:merge"))
-	  (t (monky-run-hg-async "pull" remote)))))
+    (monky-run-hg-async "pull" monky-pull-args remote)))
 
 (defun monky-remotes ()
   (mapcar #'car (monky-hg-config-section "paths")))

--- a/monky.el
+++ b/monky.el
@@ -1472,11 +1472,11 @@ With a prefix argument, visit in other window."
 
 (defun monky-checkout (node)
   (interactive (list (monky-read-revision "Update to: ")))
-  (monky-run-hg "update" node "--tool" "internal:merge"))
+  (monky-run-hg "update" node))
 
 (defun monky-merge (node)
   (interactive (list (monky-read-revision "Merge with: ")))
-  (monky-run-hg "merge" node "--tool" "internal:merge"))
+  (monky-run-hg "merge" node))
 
 (defun monky-reset-tip ()
   (interactive)

--- a/monky.el
+++ b/monky.el
@@ -113,10 +113,10 @@ is usually faster if Monky runs several commands."
   :type '(choice (const :tag "Single processes" :value nil)
                  (const :tag "Use command server" :value cmdserver)))
 
-(defcustom monky-pull-args ""
+(defcustom monky-pull-args ()
   "Extra args to pass to pull."
   :group 'monky
-  :type 'string)
+  :type '(repeat string))
 
 (defcustom monky-repository-paths nil
   "*Paths where to find repositories.  For each repository an alias is defined, which can then be passed to `monky-open-repository` to open the repository.
@@ -1437,12 +1437,13 @@ With a prefix argument, visit in other window."
 ;;; Updating
 
 (defun monky-pull ()
-  "Run hg pull.  If monky-run-update-after-pull is t, also run hg update."
+  "Run hg pull. The monky-pull-args variable contains extra arguments to pass to hg."
   (interactive)
   (let ((remote (if current-prefix-arg
                     (monky-read-remote "Pull from : ")
                   monky-incoming-repository)))
-    (monky-run-hg-async "pull" monky-pull-args remote)))
+    (apply #'monky-run-hg-async
+	   "pull" (append monky-pull-args '(remote)))))
 
 (defun monky-remotes ()
   (mapcar #'car (monky-hg-config-section "paths")))

--- a/monky.el
+++ b/monky.el
@@ -113,7 +113,7 @@ is usually faster if Monky runs several commands."
   :type '(choice (const :tag "Single processes" :value nil)
                  (const :tag "Use command server" :value cmdserver)))
 
-(defcustom monky-pull-args ()
+(defcustom monky-pull-args ("--config" "ui.merge=:merge")
   "Extra args to pass to pull."
   :group 'monky
   :type '(repeat string))

--- a/monky.el
+++ b/monky.el
@@ -1443,7 +1443,7 @@ With a prefix argument, visit in other window."
                     (monky-read-remote "Pull from : ")
                   monky-incoming-repository)))
     (apply #'monky-run-hg-async
-	   "pull" (append monky-pull-args '(remote)))))
+	   "pull" (append monky-pull-args (list remote)))))
 
 (defun monky-remotes ()
   (mapcar #'car (monky-hg-config-section "paths")))

--- a/monky.el
+++ b/monky.el
@@ -39,7 +39,7 @@
   :group 'monky
   :type 'string)
 
-(defcustom monky-hg-standard-options '("--config" "diff.git=Off")
+(defcustom monky-hg-standard-options '("--config" "diff.git=Off" "--config" "ui.merge=:merge")
   "Standard options when running Hg."
   :group 'monky
   :type '(repeat string))
@@ -113,7 +113,7 @@ is usually faster if Monky runs several commands."
   :type '(choice (const :tag "Single processes" :value nil)
                  (const :tag "Use command server" :value cmdserver)))
 
-(defcustom monky-pull-args ("--config" "ui.merge=:merge")
+(defcustom monky-pull-args ()
   "Extra args to pass to pull."
   :group 'monky
   :type '(repeat string))

--- a/monky.el
+++ b/monky.el
@@ -118,6 +118,11 @@ is usually faster if Monky runs several commands."
   :group 'monky
   :type 'boolean)
 
+(defcustom monky-run-rebase-after-pull nil
+  "Run rebase after pulling."
+  :group 'monky
+  :type 'boolean)
+
 (defcustom monky-repository-paths nil
   "*Paths where to find repositories.  For each repository an alias is defined, which can then be passed to `monky-open-repository` to open the repository.
 
@@ -1445,6 +1450,9 @@ With a prefix argument, visit in other window."
     (cond (monky-run-update-after-pull
 	   (monky-run-hg-sync "pull" remote)
 	   (monky-run-hg-async "update" "--tool" "internal:merge"))
+	  (monky-run-rebase-after-pull
+	   (monky-run-hg-sync "pull" remote)
+	   (monky-run-hg-async "rebase" "--tool" "internal:merge"))
 	  (t (monky-run-hg-async "pull" remote)))))
 
 (defun monky-remotes ()

--- a/monky.el
+++ b/monky.el
@@ -1226,6 +1226,9 @@ IF FLAG-OR-FUNC is a Boolean value, the section will be hidden if its true, show
                         args))))
 
 (defun monky-run-hg-sync (&rest args)
+    (message "Running %s %s"
+           monky-hg-executable
+           (mapconcat #'identity args " "))
   (monky-run* (append (cons monky-hg-executable
 			    monky-hg-standard-options)
 		      args)))


### PR DESCRIPTION
Hi, I implemented some new features that I found useful

- merging and updating doesn't open an external merge editor.  You can use ediff on the unresolved file by pressing e.  Also fixes a bug where an unresolved item doesn't show up.
- Pressing e on a diff prompts for a repository, and shows a diff using ediff
- Pressing enter on a branch checks out the branch
- Optional run update after a pull (with a customizable variable)
- Merge branches and revisions by pressing M on a branch or revision.  Pressing M in the status buffer prompts for a revision.
- Open repositories using an alias, by calling monky-open-repository

I removed fetch, because it's a deprecated command.