### PR TITLE
do not include empty remote when pushing to a repository

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -1365,7 +1365,9 @@ With a prefix argument, visit in other window."
                      (monky-read-remote
                       (format "Push branch %s to : " branch))
                    monky-outgoing-repository)))
-    (monky-run-hg-async "push" "--branch" branch remote)))
+    (if (string= "" remote)
+        (monky-run-hg-async "push" "--branch" branch)
+      (monky-run-hg-async "push" "--branch" branch remote))))
 
 (defun monky-checkout (node)
   (interactive (list (monky-read-revision "Update to : ")))


### PR DESCRIPTION
Hi,

This commit fixes the issue that I raised earlier https://github.com/ananthakumaran/monky/issues/52.

In summary, the variable `monky-outgoing-repository` is set to empty string `""` by default, 
which may make the variable `remote` to become an empty string as well.

Later on, a list of arguments to a `hg` command will be concatenated using a whitespace separator ` `.
This makes the hg command contains an empty space at the end like: `(hg --config diff.git=Off push --branch branch-name )`, which makes the `hg push` command fails.

In my fix, when the variable `remote` is an empty string, I will not include it in the arguments of the hg command.


