### PR TITLE
Use make-temp-file vs make-temp-name as it is not safe

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -1607,9 +1607,7 @@ before the last command."
   "Create a temporary file name, evaluate BODY and delete the file."
   (declare (indent 1)
            (debug (symbolp body)))
-  `(let ((,file (expand-file-name
-                 (make-temp-name "monky-temp-file")
-                 temporary-file-directory)))
+  `(let ((,file (make-temp-file "monky-temp-file")))
      (unwind-protect
          (progn ,@body)
        (delete-file ,file))))


### PR DESCRIPTION
There is a race condition between calling ‘make-temp-name’ and
later creating the file, which opens all kinds of security holes.
For that reason, you should normally use ‘make-temp-file’ instead.

This also makes the code simpler as it automatically performs the
expansion with temporary-file-directory.