### PR TITLE
ci: add travis-ci integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: emacs-lisp
+sudo: false
+before_install:
+  - git clone https://github.com/rejeep/evm.git /home/travis/.evm
+  - export PATH="/home/travis/.evm/bin:$PATH"
+  - evm config path /tmp
+  - evm install $EVM_EMACS --use
+env:
+  - EVM_EMACS=emacs-24.4-travis
+  - EVM_EMACS=emacs-25.1-travis
+  - EVM_EMACS=emacs-25.2-travis
+  - EVM_EMACS=emacs-25.3-travis
+  - EVM_EMACS=emacs-26.1-travis
+  - EVM_EMACS=emacs-git-snapshot-travis
+script:
+  - emacs --version
+  - make monky.elc


### PR DESCRIPTION
Start the CI journey for the project. We will check that monky will compile
under emacs 24.4,25.1,25.2,25.3,26.1 and master

I plan on contributing some big refactorings and new features, so this will
hopefully give us some confidence :-)