### PR TITLE
Add monky-log-revset.

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -699,6 +699,7 @@ FUNC should leave point at the end of the modified region"
     (define-key map (kbd ":") 'monky-hg-command)
     (define-key map (kbd "l l") 'monky-log-current-branch)
     (define-key map (kbd "l a") 'monky-log-all)
+    (define-key map (kbd "l r") 'monky-log-revset)
     (define-key map (kbd "b") 'monky-branches)
     (define-key map (kbd "Q") 'monky-queue)
     (define-key map (kbd "q") 'monky-quit-window)
@@ -2239,6 +2240,10 @@ PROPERTIES is the arguments for the function `propertize'."
 (defun monky-log-all ()
   (interactive)
   (monky-log nil))
+
+(defun monky-log-revset (revset)
+  (interactive  "sRevset: ")
+  (monky-log revset))
 
 (defun monky-log (revs)
   (monky-with-process


### PR DESCRIPTION
This is occasionally useful, in particular for custom revset aliases that show `!public()` changsets or other work-in-progress.