### PR TITLE
Fix broken monky-get-tramp-root-dir

### DIFF
--- a/monky.el
+++ b/monky.el
@@ -1791,11 +1791,11 @@ before the last command."
 
 (defun monky-get-tramp-root-dir ()
   (let ((root (monky-hg-string "root"))
-	      (tramp-path (vconcat (tramp-dissect-file-name default-directory))))
+        (tramp-path (vconcat (tramp-dissect-file-name default-directory))))
     (if root
-	      (progn (aset tramp-path 6 root)
-	             (concat (apply 'tramp-make-tramp-file-name (cdr (append tramp-path nil)))
-		                   "/"))
+        (progn (aset tramp-path 6 root)
+               (concat (apply 'tramp-make-tramp-file-name (cdr (append tramp-path nil)))
+                       "/"))
       (user-error "Not inside a hg repo"))))
 
 (defun monky-find-buffer (submode &optional dir)

--- a/monky.el
+++ b/monky.el
@@ -1791,11 +1791,11 @@ before the last command."
 
 (defun monky-get-tramp-root-dir ()
   (let ((root (monky-hg-string "root"))
-	(tramp-path (tramp-dissect-file-name default-directory)))
+	      (tramp-path (vconcat (tramp-dissect-file-name default-directory))))
     (if root
-	(progn (aset tramp-path 3 root)
-	       (concat (apply 'tramp-make-tramp-file-name (append tramp-path ()))
-		       "/"))
+	      (progn (aset tramp-path 6 root)
+	             (concat (apply 'tramp-make-tramp-file-name (cdr (append tramp-path nil)))
+		                   "/"))
       (user-error "Not inside a hg repo"))))
 
 (defun monky-find-buffer (submode &optional dir)


### PR DESCRIPTION
Currently, monky-get-tramp-root dir is broken. This patch applies the following changes

- convert output of tramp-dissect-file-name from list to vector before using aset
- replace 6th (not 3rd) entry in tramp-path with root dir
- correctly convert modified vector to tramp-make-tramp-file-name args